### PR TITLE
Fix compatibility with Webpack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # CustomVarLibraryNamePlugin
 
-A WebPack ~~hack~~ plugin to allow to set a different module name to the var `libraryTarget` and the AMD/CommonJS when using `libraryTarget:'umd'`.
+A WebPack ~~hack~~ plugin to allow to set a different module name to the var `libraryTarget` and the AMD/CommonJS when using `libraryTarget:'umd'`. 
+
+The latest relase adds the hability to change the file name and handle multiple bundle names.
 
 ## Install
 
@@ -16,9 +18,28 @@ var CustomVarLibraryNamePlugin = require('webpack-custom-var-library-name-plugin
     plugins: [
         ...
         new CustomVarLibraryNamePlugin({
-          name: 'auth0'
+          name: 'var-name'
         }),
         ...
     ],
 ...
+```
+
+```js
+var CustomVarLibraryNamePlugin = require('webpack-custom-var-library-name-plugin');
+
+    plugins: [
+        ...
+        new CustomVarLibraryNamePlugin({
+          name: {
+            'chunk-name': {
+                var: 'var-name',
+                file: 'file-name'
+            }
+          }
+        }),
+        ...
+    ],
+...
+```
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,16 @@ CustomVarLibraryNamePlugin.prototype.apply = function(compiler) {
 
       if (_this.options.name[key].file) {
         prev.push({
+          replace: key +'.min.js.map',
+          with: _this.options.name[key].file +'.min.js.map'
+        })
+        prev.push({
           replace: key +'.js',
           with: _this.options.name[key].file +'.js'
+        })
+        prev.push({
+          replace: key +'.min.js',
+          with: _this.options.name[key].file +'.min.js'
         })
       }
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,27 @@ function CustomVarLibraryNamePlugin(options) {
 
 CustomVarLibraryNamePlugin.prototype.apply = function(compiler) {
   var _this = this;
+  var replaceMap = null;
+
+  if (typeof _this.options.name === 'object') {
+    replaceMap = Object.keys(_this.options.name).reduce(function(prev, key) {
+      if (_this.options.name[key].var) {
+        prev.push({
+          replace: 'root["'+ key +'"]',
+          with: 'root["'+ _this.options.name[key].var +'"]'
+        })
+      }
+
+      if (_this.options.name[key].file) {
+        prev.push({
+          replace: key +'.js',
+          with: _this.options.name[key].file +'.js'
+        })
+      }
+
+      return prev;
+    }, []);
+  }
 
   compiler.plugin("compilation", function(compilation) {
 
@@ -11,7 +32,17 @@ CustomVarLibraryNamePlugin.prototype.apply = function(compiler) {
 
     mainTemplate.plugin('asset-path', function(path, data) {
 
-      return path.indexOf('root[') === 0 ? 'root["' + _this.options.name + '"]' : path;
+      if (replaceMap) {
+        if (data.chunk && data.chunk.name) {
+          path = path.replace('[name]', data.chunk.name);
+        }
+
+        return replaceMap.reduce(function(prev, curr) {
+          return prev.replace(curr.replace, curr.with);
+        }, path);
+      } else {
+        return path.indexOf('root[') === 0 ? 'root["' + _this.options.name + '"]' : path;
+      }
 
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-custom-var-library-name-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {},

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "bugs": {
     "url": "https://github.com/glena/webpack-custom-var-library-name-plugin/issues"
   },
+  "peerDependencies": {
+    "webpack": "^4.16.0"
+  },
   "homepage": "https://github.com/glena/webpack-custom-var-library-name-plugin#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "webpack-custom-var-library-name-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
-  "scripts": {
-  },
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/glena/webpack-custom-var-library-name-plugin.git"


### PR DESCRIPTION
As of webpack 4 tapable.plugin is deprecated and will complain.
In order to remove the annoying warning and to optimize a little, here is a PR that will bring back compatibility.